### PR TITLE
Fancy continuous integration with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: java
 
+sudo: false
+
 script: mvn clean test
 
 jdk:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 language: java
-script:
-  - jdk_switcher use oraclejdk8
+
+script: mvn clean test
+
+jdk:
+- openjdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ language: java
 script: mvn clean test
 
 jdk:
-- openjdk8
+- oraclejdk8

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# JavaBasics
+A playground for all the happy Java learners outside.
+
+Travis just reported the latest status of our project is 
+[![Build Status](https://travis-ci.org/mle-enso/JavaBasics.svg?branch=master)](https://travis-ci.org/mle-enso/JavaBasics)


### PR DESCRIPTION
I propose the next change to run your project continuously with every pushed commit against the Travis CI (Continuous Integration) infrastructure. Without any manual steps this executes all the tests in the project and reports the success state. I've done this already for my fork of your project and you can see the results of the last build there: https://travis-ci.org/mle-enso/JavaBasics/builds/170236397

Why not reading the [beginners tutorial](https://docs.travis-ci.com/user/for-beginners) in preparation of our next development talk?
